### PR TITLE
Fixed signing data containing special characters

### DIFF
--- a/lib/plivo.js
+++ b/lib/plivo.js
@@ -107,7 +107,7 @@ plivo.create_signature = function (url, params) {
 
   var signature = crypto
     .createHmac('sha1', plivo.options.authToken)
-    .update(toSign)
+    .update(new Buffer(toSign, 'utf-8'))
     .digest('base64');
 
   return signature;


### PR DESCRIPTION
Fix plivo.create_signature when signing data containing special characters (e.g. sms message containing emoji 👦)